### PR TITLE
Use webrender::api instead of webrender_api.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ log = "0.3"
 gleam = "0.4.7"
 
 webrender = { git = "https://github.com/servo/webrender", rev = "ba51d8d5892d7ff8a69a9657c882b620595de4f7" }
-webrender_api = { git = "https://github.com/servo/webrender", rev = "ba51d8d5892d7ff8a69a9657c882b620595de4f7" }
 
 stb_truetype = "0.2.1"
 app_units = "0.5"

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -2,7 +2,7 @@
 extern crate limn;
 #[macro_use]
 extern crate limn_layout;
-extern crate webrender_api;
+extern crate webrender;
 extern crate euclid;
 
 extern crate chrono;
@@ -13,7 +13,7 @@ use std::f32;
 use std::{thread, time};
 
 use chrono::{Local, Timelike};
-use webrender_api::*;
+use webrender::api::*;
 
 use limn::prelude::*;
 use limn::draw::ellipse::{EllipseState, EllipseStyle};

--- a/src/draw/ellipse.rs
+++ b/src/draw/ellipse.rs
@@ -1,4 +1,4 @@
-use webrender_api::{ComplexClipRegion, BorderRadius, LocalClip, PrimitiveInfo};
+use webrender::api::{ComplexClipRegion, BorderRadius, LocalClip, PrimitiveInfo};
 
 use render::RenderBuilder;
 use widget::draw::Draw;

--- a/src/draw/image.rs
+++ b/src/draw/image.rs
@@ -1,4 +1,4 @@
-use webrender_api::*;
+use webrender::api::*;
 
 use render::RenderBuilder;
 use widget::draw::Draw;

--- a/src/draw/rect.rs
+++ b/src/draw/rect.rs
@@ -1,4 +1,4 @@
-use webrender_api::{LocalClip, BorderRadius, ComplexClipRegion, PrimitiveInfo};
+use webrender::api::{LocalClip, BorderRadius, ComplexClipRegion, PrimitiveInfo};
 
 use render::RenderBuilder;
 use widget::draw::Draw;

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -1,4 +1,4 @@
-use webrender_api::{LayoutPoint, GlyphInstance, PrimitiveInfo, FontInstanceKey};
+use webrender::api::{LayoutPoint, GlyphInstance, PrimitiveInfo, FontInstanceKey};
 use rusttype::{Scale, GlyphId, VMetrics};
 
 use render::RenderBuilder;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -2,7 +2,7 @@ use std::f32;
 
 use euclid;
 use rusttype;
-use webrender_api::*;
+use webrender::api::*;
 
 pub type Size = euclid::Size2D<f32>;
 pub type Point = euclid::Point2D<f32>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ extern crate euclid;
 #[macro_use]
 extern crate log;
 extern crate webrender;
-extern crate webrender_api;
 extern crate gleam;
 extern crate app_units;
 extern crate image;


### PR DESCRIPTION
WebRender now re-exports the `webrender_api` crate, so we can just
have a single dependency on `webrender` rather than both that and
the `webrender_api` crate.