### PR TITLE
Remove trivial numeric casts.

### DIFF
--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -316,10 +316,10 @@ impl EventHandler<ScrollParentEvent> for ScrollParent {
 fn get_scroll(event: glutin::MouseScrollDelta) -> Vector {
     let vec = match event {
         glutin::MouseScrollDelta::LineDelta(x, y) => {
-            Vector::new(-x as f32, y as f32)
+            Vector::new(-x, y)
         }
         glutin::MouseScrollDelta::PixelDelta(x, y) => {
-            Vector::new(-x as f32, y as f32)
+            Vector::new(-x, y)
         }
     };
     vec * 13.0


### PR DESCRIPTION
These values are already `f32`, so no need to cast them.

This is a check that can be enabled with `#![deny(trivial_numeric_casts)]`.