### PR TITLE
Deps: Update linked-hash-map to 0.5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ glutin = { git = "https://github.com/christolliday/glutin", branch = "fix_window
 image = "0.15"
 
 lazy_static = "0.2.2"
-linked-hash-map = "0.3.0"
+linked-hash-map = "0.5.0"
 stable_bst = "0.2.0"
 maplit = "0.1.4"
 downcast-rs = "1.0.0"


### PR DESCRIPTION
`rusttype` also pulls this in, so we were building both the `0.3` and
`0.5` versions of `linked-hash-map`.