### PR TITLE
Rename window::size_* to indicate device vs layout.

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -48,7 +48,7 @@ impl WebRenderContext {
         let (renderer, sender) = webrender::Renderer::new(gl, opts).unwrap();
         let api = sender.create_api();
         resources::init_resources(sender.create_api());
-        let document_id = api.add_document(window.size_u32());
+        let document_id = api.add_document(window.device_size());
 
         let frame_ready = Arc::new(AtomicBool::new(false));
         let notifier = Box::new(Notifier::new(events_loop.create_proxy(), frame_ready.clone()));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -93,7 +93,7 @@ impl Ui {
     }
 
     pub(super) fn window_resized(&mut self, window_dims: Size) {
-        let window_size = self.window.borrow_mut().size_u32();
+        let window_size = self.window.borrow_mut().device_size();
         self.render.window_resized(window_size);
         let mut root = self.get_root();
 
@@ -143,7 +143,7 @@ impl Ui {
     }
 
     fn draw(&mut self) {
-        let window_size = self.window.borrow_mut().size_f32();
+        let window_size = self.window.borrow_mut().layout_size();
         let (builder, resources) = {
             let mut renderer = self.render.render_builder(window_size);
             let crop_to = Rect::new(Point::zero(), Size::new(::std::f32::MAX, ::std::f32::MAX));
@@ -159,7 +159,7 @@ impl Ui {
 
     // Call after drawing
     pub(super) fn update(&mut self) {
-        self.render.update(self.window.borrow_mut().size_u32());
+        self.render.update(self.window.borrow_mut().device_size());
         let window = self.window.borrow_mut();
         window.swap_buffers();
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -44,11 +44,11 @@ impl Window {
     pub fn resize(&mut self, width: u32, height: u32) {
         self.window.set_inner_size(width, height);
     }
-    pub fn size_u32(&self) -> DeviceUintSize {
+    pub fn device_size(&self) -> DeviceUintSize {
         let (width, height) = self.window.get_inner_size_pixels().unwrap();
         DeviceUintSize::new(width, height)
     }
-    pub fn size_f32(&self) -> LayoutSize {
+    pub fn layout_size(&self) -> LayoutSize {
         let (width, height) = self.window.get_inner_size_pixels().unwrap();
         LayoutSize::new(width as f32, height as f32)
     }


### PR DESCRIPTION
The `size_f32` method becomes `layout_size` to better indicate what
it is for, and the `size_u32` method becomes `device_size`.