### PR TITLE
Fixes for clippy, added documentation effort

### DIFF
--- a/examples/circles.rs
+++ b/examples/circles.rs
@@ -57,7 +57,7 @@ impl SliderControl {
         let slider_value_ref = slider_value.widget_ref();
         slider_widget.add_handler_fn(move |event: &SliderEvent, args| {
             slider_value_ref.event(TextUpdated((event.value as i32).to_string()));
-            args.ui.event(AppEvent::Resize(event.clone()));
+            args.ui.event(AppEvent::Resize(*event));
         });
         let slider_widget_ref = slider_widget.widget_ref();
         let slider_value_ref = slider_value.widget_ref();
@@ -140,7 +140,7 @@ fn create_circle(id: CircleId, circle: &Circle, parent_ref: &mut WidgetRef) -> W
         .set_draw_state_with_style(EllipseState::new(), style)
         .make_draggable()
         .add_handler_fn(|event: &DragEvent, args| {
-            args.widget.event(CircleEvent::Drag(event.clone()));
+            args.widget.event(CircleEvent::Drag(*event));
         })
         .add_handler(CircleHandler(id));
     let widget_ref = widget.widget_ref();

--- a/examples/circles.rs
+++ b/examples/circles.rs
@@ -328,7 +328,7 @@ impl EventHandler<AppEvent> for AppEventHandler {
             AppEvent::ClickCanvas(point) => {
                 if self.create_mode {
                     let circle = Circle { center: point, size: 100.0 };
-                    let circle_id = self.id_gen.next();
+                    let circle_id = self.id_gen.next_id();
                     self.new_change(Change::Create(circle_id, circle));
                 } else {
                     self.update_selected(None);

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate limn;
 #[macro_use]
 extern crate limn_layout;

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 #[macro_use]
 extern crate limn;
 #[macro_use]

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -93,7 +93,7 @@ impl PeopleHandler {
         }
     }
     fn add_person(&mut self) {
-        let id = self.id_gen.next();
+        let id = self.id_gen.next_id();
         self.people.insert(id, self.person.clone());
         let list_item_widget = {
             let text_style = style!(TextStyle::TextColor: WHITE);

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate limn;
 #[macro_use]
 extern crate limn_layout;

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,4 +1,5 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
+
 #[macro_use]
 extern crate limn;
 #[macro_use]

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 #[macro_use]
 extern crate limn;
 #[macro_use]

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate limn;
 #[macro_use]
 extern crate limn_layout;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,4 +1,5 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
+
 #[macro_use]
 extern crate limn;
 #[macro_use]

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 #[macro_use]
 extern crate limn;
 #[macro_use]

--- a/examples/opengl_boxes.rs
+++ b/examples/opengl_boxes.rs
@@ -26,6 +26,8 @@ use limn::input::{EscKeyCloseHandler, DebugSettingsHandler};
 use limn::widgets::slider::{SliderBuilder, SliderEvent};
 use limn::widgets::glcanvas::{GLCanvasBuilder, GLCanvasState};
 
+pub const FLOATING_PT_ERROR: f64 = 0.0001;
+
 fn init_framebuffer(gl: &Rc<gl::Gl>) -> (GLuint, GLuint, GLuint) {
     // Make a texture that will be sent to WebRender
     let tex = gl.gen_textures(1)[0];
@@ -38,7 +40,7 @@ fn init_framebuffer(gl: &Rc<gl::Gl>) -> (GLuint, GLuint, GLuint) {
     gl.bind_framebuffer(gl::FRAMEBUFFER, fb);
 
     // Set them up
-    resize_destination(&gl, tex, depth_buf, 1024, 768);
+    resize_destination(gl, tex, depth_buf, 1024, 768);
 
     // Unbind the framebuffer (so that WebRender will render to the window)
     gl.bind_framebuffer(gl::FRAMEBUFFER, 0);
@@ -237,7 +239,7 @@ fn main() {
     let mut root = WidgetBuilder::new("root");
 
     // Create an image that's connected to the texture we're rendering to
-    let mut gl_canvas = GLCanvasBuilder::new("gl_canvas", tex as _);
+    let mut gl_canvas = GLCanvasBuilder::new("gl_canvas", u64::from(tex));
     gl_canvas.layout().no_container();
     gl_canvas.layout().add(constraints![
         match_width(&root),
@@ -259,7 +261,8 @@ fn main() {
         if let Some(state) = gl_canvas_ref.draw_state().downcast_ref::<GLCanvasState>() {
             let old_size = target_size.get();
             let new_size = state.measure();
-            if new_size.width != old_size.0 || new_size.height != old_size.1 {
+            if (new_size.width - old_size.0).abs() > FLOATING_PT_ERROR ||
+               (new_size.height - old_size.1).abs() > FLOATING_PT_ERROR {
                 target_size.set((new_size.width, new_size.height));
                 resize_destination(&gl, tex, depth_buf, new_size.width as _, new_size.height as _);
             }

--- a/examples/opengl_boxes.rs
+++ b/examples/opengl_boxes.rs
@@ -26,7 +26,7 @@ use limn::input::{EscKeyCloseHandler, DebugSettingsHandler};
 use limn::widgets::slider::{SliderBuilder, SliderEvent};
 use limn::widgets::glcanvas::{GLCanvasBuilder, GLCanvasState};
 
-pub const FLOATING_PT_ERROR: f64 = 0.0001;
+pub const FLOATING_PT_ERROR: f32 = 0.0001;
 
 fn init_framebuffer(gl: &Rc<gl::Gl>) -> (GLuint, GLuint, GLuint) {
     // Make a texture that will be sent to WebRender

--- a/examples/opengl_boxes.rs
+++ b/examples/opengl_boxes.rs
@@ -190,6 +190,7 @@ lazy_static! {
     static ref VIEW_MATRIX: Transform3D<GLfloat> = view_matrix(Vector3D::new(0.0, 5.0, 2.0), Vector3D::new(0.0, 0.4, 0.0));
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
 fn draw_boxes(gl: &Rc<gl::Gl>, prog: GLuint, model: GLuint,
               width: GLint, height: GLint, box_count: usize,
               time_cell: &Cell<f32>, scale_cell: &Cell<f32>) {

--- a/examples/opengl_boxes.rs
+++ b/examples/opengl_boxes.rs
@@ -26,8 +26,6 @@ use limn::input::{EscKeyCloseHandler, DebugSettingsHandler};
 use limn::widgets::slider::{SliderBuilder, SliderEvent};
 use limn::widgets::glcanvas::{GLCanvasBuilder, GLCanvasState};
 
-pub const FLOATING_PT_ERROR: f32 = 0.0001;
-
 fn init_framebuffer(gl: &Rc<gl::Gl>) -> (GLuint, GLuint, GLuint) {
     // Make a texture that will be sent to WebRender
     let tex = gl.gen_textures(1)[0];
@@ -260,10 +258,9 @@ fn main() {
 
         // Handle widget size changes
         if let Some(state) = gl_canvas_ref.draw_state().downcast_ref::<GLCanvasState>() {
-            let old_size = target_size.get();
+            let (old_size_width, old_size_height) = target_size.get();
             let new_size = state.measure();
-            if (new_size.width - old_size.0).abs() > FLOATING_PT_ERROR ||
-               (new_size.height - old_size.1).abs() > FLOATING_PT_ERROR {
+            if new_size.width != old_size_width || new_size.height != old_size_height {
                 target_size.set((new_size.width, new_size.height));
                 resize_destination(&gl, tex, depth_buf, new_size.width as _, new_size.height as _);
             }

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -22,7 +22,7 @@ fn main() {
 
     {
         let mut add_rect = |color| {
-            let mut rect = WidgetBuilder::new(&format!("rect_{:?}", color));
+            let mut rect = WidgetBuilder::new(format!("rect_{:?}", color));
             rect.set_draw_state_with_style(RectState::new(),
                 style!(RectStyle::BackgroundColor: color));
             rect_container.add_child(rect);

--- a/layout/src/constraint.rs
+++ b/layout/src/constraint.rs
@@ -135,7 +135,7 @@ pub fn match_height<T: LayoutRef>(widget: &T) -> PaddableConstraintBuilder {
     PaddableConstraint::MatchHeight(widget.height).builder(REQUIRED)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum WidgetConstraint {
     Width(f32),
     Height(f32),
@@ -153,7 +153,7 @@ pub enum WidgetConstraint {
     CenterVertical(Variable, Variable),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum PaddableConstraint {
     AlignTop(Variable),
     AlignBottom(Variable),
@@ -176,6 +176,7 @@ pub enum PaddableConstraint {
     MatchWidth(Variable),
     MatchHeight(Variable),
 }
+
 impl WidgetConstraint {
     pub fn builder(self, default_strength: f64) -> WidgetConstraintBuilder {
         WidgetConstraintBuilder {
@@ -184,6 +185,7 @@ impl WidgetConstraint {
         }
     }
 }
+
 impl PaddableConstraint {
     pub fn builder(self, default_strength: f64) -> PaddableConstraintBuilder {
         PaddableConstraintBuilder {
@@ -194,10 +196,12 @@ impl PaddableConstraint {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetConstraintBuilder {
     constraint: WidgetConstraint,
     strength: f64,
 }
+
 impl WidgetConstraintBuilder {
     pub fn strength(mut self, strength: f64) -> Self {
         self.strength = strength;
@@ -205,11 +209,13 @@ impl WidgetConstraintBuilder {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct PaddableConstraintBuilder {
     constraint: PaddableConstraint,
     strength: f64,
     padding: f32,
 }
+
 impl PaddableConstraintBuilder {
     pub fn strength(mut self, strength: f64) -> Self {
         self.strength = strength;

--- a/layout/src/grid_layout.rs
+++ b/layout/src/grid_layout.rs
@@ -4,6 +4,7 @@ use cassowary::WeightedRelation::*;
 use super::{LayoutVars, Layout, Constraint, LayoutContainer};
 use super::constraint::*;
 
+#[derive(Debug, Clone)]
 pub struct GridLayout {
     num_columns: usize,
     column: usize,

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -1,3 +1,9 @@
+// ---- START CLIPPY CONFIG
+
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
 // Enable clippy if our Cargo.toml file asked us to do so.
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
@@ -25,6 +31,8 @@
 #![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
 #![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
 #![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
+// ---- END CLIPPY CONFIG
 
 #[macro_use]
 extern crate log;
@@ -118,17 +126,20 @@ pub trait LayoutRef {
 
 impl<'a> LayoutRef for &'a mut Layout {
     fn layout_ref(&self) -> LayoutVars {
-        self.vars.clone()
+        self.vars
     }
 }
+
 impl LayoutRef for Layout {
     fn layout_ref(&self) -> LayoutVars {
-        self.vars.clone()
+        self.vars
     }
 }
+
 impl LayoutRef for LayoutVars {
+    /// Returns a copy of the current `LayoutVars`
     fn layout_ref(&self) -> LayoutVars {
-        self.clone()
+        *self
     }
 }
 

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -1,9 +1,37 @@
-extern crate cassowary;
-extern crate euclid;
+// Enable clippy if our Cargo.toml file asked us to do so.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+#![warn(missing_copy_implementations,
+        trivial_numeric_casts,
+        trivial_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications)]
+#![cfg_attr(feature="clippy", warn(cast_possible_truncation))]
+#![cfg_attr(feature="clippy", warn(cast_possible_wrap))]
+#![cfg_attr(feature="clippy", warn(cast_precision_loss))]
+#![cfg_attr(feature="clippy", warn(cast_sign_loss))]
+#![cfg_attr(feature="clippy", warn(missing_docs_in_private_items))]
+#![cfg_attr(feature="clippy", warn(mut_mut))]
+
+// Disallow `println!`. Use `debug!` for debug output
+// (which is provided by the `log` crate).
+#![cfg_attr(feature="clippy", warn(print_stdout))]
+
+// This allows us to use `unwrap` on `Option` values (because doing makes
+// working with Regex matches much nicer) and when compiling in test mode
+// (because using it in tests is idiomatic).
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
+extern crate cassowary;
+extern crate euclid;
 
 use std::collections::HashSet;
 use std::ops::Drop;
@@ -27,7 +55,7 @@ pub type Rect = euclid::Rect<f32>;
 
 pub type LayoutId = usize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LayoutVars {
     pub left: Variable,
     pub top: Variable,
@@ -36,7 +64,10 @@ pub struct LayoutVars {
     pub width: Variable,
     pub height: Variable,
 }
+
 impl LayoutVars {
+
+    /// Creates a new set of empty `LayoutVars`
     pub fn new() -> Self {
         LayoutVars {
             left: Variable::new(),
@@ -47,9 +78,18 @@ impl LayoutVars {
             height: Variable::new(),
         }
     }
+
+    /// Returns the current inner state of this struct as an array
     pub fn array(&self) -> [Variable; 6] {
-        [self.left, self.top, self.right, self.bottom, self.width, self.height]
+        [self.left,
+         self.top,
+         self.right,
+         self.bottom,
+         self.width,
+         self.height]
     }
+
+    /// Checks if another `Variable` is the same as the
     pub fn var_type(&self, var: Variable) -> VarType {
         if var == self.left { VarType::Left }
         else if var == self.top { VarType::Top }
@@ -107,7 +147,10 @@ pub struct Layout {
     associated_vars: Vec<(Variable, String)>,
     pub hidden: bool,
 }
+
 impl Layout {
+
+    /// Creates a new `Layout`.
     pub fn new(id: LayoutId, name: Option<String>) -> Self {
         let vars = LayoutVars::new();
         let mut new_constraints = HashSet::new();
@@ -131,13 +174,18 @@ impl Layout {
             hidden: false,
         }
     }
+
     pub fn layout(&mut self) -> &mut Self {
         self
     }
+
+    /// Clears the container of the current `Layout`.
     pub fn no_container(&mut self) {
         self.container = None;
     }
-    pub fn set_container<T: LayoutContainer + 'static>(&mut self, container: T) {
+
+    /// Replaces the container of the current layout
+    pub fn set_container<T>(&mut self, container: T) where T: LayoutContainer + 'static {
         self.container = Some(Rc::new(RefCell::new(container)));
     }
     pub fn edit_left(&mut self) -> VariableEditable {
@@ -256,6 +304,7 @@ pub struct VariableEditable<'a> {
     val: Option<f64>,
     strength: f64,
 }
+
 impl<'a> VariableEditable<'a> {
     pub fn new(builder: &'a mut Layout, var: Variable) -> Self {
         VariableEditable {
@@ -274,18 +323,21 @@ impl<'a> VariableEditable<'a> {
         self
     }
 }
+
 impl<'a> Drop for VariableEditable<'a> {
     fn drop(&mut self) {
         let edit_var = EditVariable::new(&self);
         self.builder.edit_vars.push(edit_var);
     }
 }
-#[derive(Debug)]
+
+#[derive(Debug, Copy, Clone)]
 pub struct EditVariable {
     var: Variable,
     val: f64,
     strength: f64,
 }
+
 impl EditVariable {
     fn new(editable: &VariableEditable) -> Self {
         EditVariable {
@@ -321,12 +373,14 @@ pub trait LayoutContainer {
     fn remove_child(&mut self, _: &mut Layout, _: &mut Layout) {}
 }
 
-#[derive(Default)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Frame {
     padding: f32,
 }
 
 impl LayoutContainer for Frame {
+
+    /// Adds a weak constraint to a Frame
     fn add_child(&mut self, parent: &mut Layout, child: &mut Layout) {
         child.add(constraints![
             bound_by(&parent).padding(self.padding),
@@ -335,6 +389,7 @@ impl LayoutContainer for Frame {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct ExactFrame;
 
 impl LayoutContainer for ExactFrame {

--- a/layout/src/linear_layout.rs
+++ b/layout/src/linear_layout.rs
@@ -8,7 +8,7 @@ use super::{LayoutId, LayoutVars, Layout, LayoutContainer};
 use super::constraint::*;
 
 /// Specifies the extra space between elements along the primary axis
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone,PartialEq)]
 pub enum Spacing {
     /// Equal spacing before, after and between all elements
     Around,
@@ -21,6 +21,7 @@ pub enum Spacing {
 }
 
 /// Specifies alignment of items perpendicular to the primary axis
+#[derive(Debug, Copy, Clone)]
 pub enum ItemAlignment {
     /// No constraints are added, items can be aligned individually
     None,
@@ -42,16 +43,24 @@ pub enum ItemAlignment {
     Bottom,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct LinearLayoutSettings {
+    /// Horizontal or vertical orientation of the current layout
     pub orientation: Orientation,
+    /// Flex-like spacing property
     pub spacing: Spacing,
+    /// Alignment of children
     pub item_align: ItemAlignment,
     /// Constrain items to have equal size along primary axis, and fill container
     pub fill_equal: bool,
+    /// Padding around the current layout in relation to the parent item
     pub padding: f32,
 }
 
 impl LinearLayoutSettings {
+
+    /// Creates a default `LinearLayoutSettings`, aligned to the
+    /// end of the parent container
     pub fn new(orientation: Orientation) -> Self {
         LinearLayoutSettings {
             orientation: orientation,
@@ -63,13 +72,13 @@ impl LinearLayoutSettings {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum Orientation {
     Horizontal,
     Vertical,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct WidgetData {
     start: Variable,
     end: Variable,
@@ -77,14 +86,13 @@ struct WidgetData {
     next: Option<LayoutId>,
     end_constraint: Option<Constraint>,
 }
+
 pub struct LinearLayout {
     settings: LinearLayoutSettings,
-
     start: Variable,
     end: Variable,
     space: Variable,
     size: Option<Variable>,
-
     widgets: HashMap<LayoutId, WidgetData>,
     last_widget: Option<LayoutId>,
 }

--- a/layout/src/solver.rs
+++ b/layout/src/solver.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write;
 
 use cassowary;
-use cassowary::strength;
 use cassowary::strength::*;
 use cassowary::{Variable, Constraint, Expression};
 use cassowary::WeightedRelation::*;
@@ -474,14 +473,15 @@ impl LayoutManager {
     }
 }
 
+/// Creates a printable string value for a given strength
 fn strength_desc(strength: f64) -> &'static str {
-    if strength < strength::WEAK { "WEAK-" }
-    else if strength == strength::WEAK { "WEAK " }
-    else if strength < strength::MEDIUM { "WEAK+" }
-    else if strength == strength::MEDIUM { "MED  " }
-    else if strength < strength::STRONG { "MED+ " }
-    else if strength == strength::STRONG { "STR  " }
-    else if strength < strength::REQUIRED { "STR+ " }
-    else if strength == strength::REQUIRED { "REQD " }
+    if strength < WEAK { "WEAK-" }
+    else if strength == WEAK { "WEAK " }
+    else if strength < MEDIUM { "WEAK+" }
+    else if strength == MEDIUM { "MED  " }
+    else if strength < STRONG { "MED+ " }
+    else if strength == STRONG { "STR  " }
+    else if strength < REQUIRED { "STR+ " }
+    else if strength == REQUIRED { "REQD " }
     else { "REQD+" }
 }

--- a/layout/tests/integration.rs
+++ b/layout/tests/integration.rs
@@ -470,15 +470,25 @@ impl TestLayout {
         true
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct IdGen {
     id: usize,
 }
-impl IdGen {
-    fn new() -> Self {
+
+impl Default for IdGen {
+    fn default() -> Self {
         IdGen {
             id: 0,
         }
     }
+}
+impl IdGen {
+
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn next(&mut self) -> LayoutId {
         let next = self.id;
         self.id += 1;

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,7 +83,7 @@ impl App {
     /// moved to asynchronous event handling.
     pub fn main_loop(mut self, root: WidgetBuilder) {
         self.ui.root.add_child(root);
-        let events_loop = self.events_loop.clone();
+        let events_loop = Rc::clone(&self.events_loop);
         let mut events_loop = events_loop.borrow_mut();
 
         // Handle set up events to allow layout to 'settle' and initialize
@@ -151,4 +151,5 @@ impl App {
 ///
 /// To implement animation, add a handler for this event that calls
 /// [`args.ui.redraw()`](../ui/struct.Ui.html#method.redraw) to draw a new frame.
+#[derive(Debug, Copy, Clone)]
 pub struct FrameEvent;

--- a/src/app.rs
+++ b/src/app.rs
@@ -79,8 +79,7 @@ impl App {
     }
 
     /// Updates the UI and redraws the window (the applications main loop)
-    /// Event handling currently blocks the whole UI, eventually this should be
-    /// moved to asynchronous event handling.
+    /// Event handling currently blocks the whole UI
     pub fn main_loop(mut self, root: WidgetBuilder) {
         self.ui.root.add_child(root);
         let events_loop = Rc::clone(&self.events_loop);

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,5 @@
+#![allow(unreadable_literal)]
+
 use std::fmt;
 use webrender::api::ColorF;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-#![allow(unreadable_literal)]
+#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 
 use std::fmt;
 use webrender::api::ColorF;

--- a/src/draw/ellipse.rs
+++ b/src/draw/ellipse.rs
@@ -7,10 +7,12 @@ use widget::style::{self, Style, Value};
 use geometry::{Rect, RectExt, Point, Size};
 use color::*;
 
+#[derive(Debug, Copy, Clone)]
 pub struct EllipseState {
     pub background_color: Color,
     pub border: Option<(f32, Color)>,
 }
+
 impl Default for EllipseState {
     fn default() -> Self {
         EllipseState {

--- a/src/draw/glcanvas.rs
+++ b/src/draw/glcanvas.rs
@@ -35,7 +35,7 @@ impl GLCanvasState {
 impl Draw for GLCanvasState {
     fn draw(&mut self, bounds: Rect, _: Rect, renderer: &mut RenderBuilder) {
         let mut res = resources();
-        let image_info = res.get_image(&self.name).clone();
+        let image_info = *res.get_image(&self.name);
         if bounds.width() as u32 != image_info.info.width ||
             bounds.height() as u32 != image_info.info.height {
             let descriptor = ImageDescriptor::new(bounds.width() as u32, bounds.height() as u32, ImageFormat::RGB8, true);

--- a/src/draw/rect.rs
+++ b/src/draw/rect.rs
@@ -7,11 +7,13 @@ use widget::style::{self, Style, Value};
 use geometry::{Rect, RectExt};
 use color::*;
 
+#[derive(Debug, Copy, Clone)]
 pub struct RectState {
     pub background_color: Color,
     pub corner_radius: Option<f32>,
     pub border: Option<(f32, Color)>,
 }
+
 impl Default for RectState {
     fn default() -> Self {
         RectState {
@@ -21,6 +23,7 @@ impl Default for RectState {
         }
     }
 }
+
 impl RectState {
     pub fn new() -> Self {
         RectState::default()

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -30,7 +30,7 @@ pub struct WidgetReceivedCharacter(pub char);
 #[derive(Default)]
 pub struct FocusHandler {
     focusable_map: HashMap<WidgetRef, usize>,
-    /// Note: can replace TreeMap with std BTreeMap once the range API or similar is stable
+    // can replace TreeMap with std BTreeMap once the range API or similar is stable
     focusable: TreeMap<usize, WidgetRef>,
     focused: Option<WidgetRef>,
     focus_index_max: usize,

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -11,38 +11,33 @@ use app::App;
 
 use glutin;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct ReceivedCharacter(pub char);
-#[derive(Clone, Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct KeyboardInput(pub glutin::ElementState, pub glutin::ScanCode, pub Option<glutin::VirtualKeyCode>);
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetKeyboardInput(pub glutin::ElementState, pub glutin::ScanCode, pub Option<glutin::VirtualKeyCode>);
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetReceivedCharacter(pub char);
 
-/**
-Note on focus:
-The tab key iterates through the widgets that have registered as focusable.
-Currently the order of this iteration is just based on the order the widgets
-are registered as focusable.
-Later on maybe it should be based on the relative positioning of widgets (could get
-ugly updating the treemap as widgets change position), or some user defined ordering.
-*/
+
+/// Note on focus:
+/// The tab key iterates through the widgets that have registered as focusable.
+/// Currently the order of this iteration is just based on the order the widgets
+/// are registered as focusable.
+/// Later on maybe it should be based on the relative positioning of widgets (could get
+/// ugly updating the treemap as widgets change position), or some user defined ordering.
+#[derive(Default)]
 pub struct FocusHandler {
     focusable_map: HashMap<WidgetRef, usize>,
-     // can replace TreeMap with std BTreeMap once the range API or similar is stable
+    /// Note: can replace TreeMap with std BTreeMap once the range API or similar is stable
     focusable: TreeMap<usize, WidgetRef>,
     focused: Option<WidgetRef>,
     focus_index_max: usize,
 }
 impl FocusHandler {
     pub fn new() -> Self {
-        FocusHandler {
-            focusable_map: HashMap::new(),
-            focusable: TreeMap::new(),
-            focused: None,
-            focus_index_max: 0,
-        }
+        Self::default()
     }
     fn set_focus(&mut self, new_focus: Option<WidgetRef>) {
         if new_focus != self.focused {
@@ -126,10 +121,10 @@ impl WidgetBuilder {
 impl App {
     pub fn add_keyboard_handlers(&mut self) {
         self.add_handler_fn(|event: &KeyboardInput, args| {
-            args.widget.event(KeyboardInputEvent::KeyboardInput(event.clone()));
+            args.widget.event(KeyboardInputEvent::KeyboardInput(*event));
         });
         self.add_handler_fn(|event: &ReceivedCharacter, args| {
-            args.widget.event(KeyboardInputEvent::ReceivedCharacter(event.clone()));
+            args.widget.event(KeyboardInputEvent::ReceivedCharacter(*event));
         });
         self.add_handler(FocusHandler::new());
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -61,11 +61,17 @@ pub struct DebugSettingsHandler {
     debug_on: bool
 }
 
-impl DebugSettingsHandler {
-    pub fn new() -> Self {
+impl Default for DebugSettingsHandler {
+    fn default() -> Self {
         DebugSettingsHandler {
             debug_on: false,
         }
+    }
+}
+
+impl DebugSettingsHandler {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -45,7 +45,9 @@ impl App {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct EscKeyCloseHandler;
+
 impl EventHandler<KeyboardInput> for EscKeyCloseHandler {
     fn handle(&mut self, event: &KeyboardInput, args: EventArgs) {
         if let KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) = *event {
@@ -53,9 +55,12 @@ impl EventHandler<KeyboardInput> for EscKeyCloseHandler {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone)]
 pub struct DebugSettingsHandler {
     debug_on: bool
 }
+
 impl DebugSettingsHandler {
     pub fn new() -> Self {
         DebugSettingsHandler {
@@ -63,6 +68,7 @@ impl DebugSettingsHandler {
         }
     }
 }
+
 impl EventHandler<KeyboardInput> for DebugSettingsHandler {
     fn handle(&mut self, event: &KeyboardInput, args: EventArgs) {
         let ui = args.ui;

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -7,14 +7,19 @@ use widget::property::Property;
 use layout::LayoutChanged;
 use app::App;
 
+#[derive(Debug, Copy, Clone)]
 pub struct MouseMoved(pub Point);
+#[derive(Debug, Copy, Clone)]
 pub struct MouseWheel(pub glutin::MouseScrollDelta);
+#[derive(Debug, Copy, Clone)]
 pub struct MouseButton(pub glutin::ElementState, pub glutin::MouseButton);
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetMouseWheel(pub glutin::MouseScrollDelta);
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetMouseButton(pub glutin::ElementState, pub glutin::MouseButton);
 
+#[derive(Debug, Copy, Clone)]
 pub enum MouseInputEvent {
     LayoutChanged,
     MouseMoved(Point),
@@ -22,22 +27,27 @@ pub enum MouseInputEvent {
     MouseWheel(glutin::MouseScrollDelta),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct ClickEvent {
     pub position: Point,
 }
 
+#[derive(Debug, Clone)]
 struct MouseController {
     pub mouse: Point,
     pub widget_under_mouse: Option<WidgetRef>,
 }
+
 impl MouseController {
+
+    /// Creates a new MouseController
     pub fn new() -> Self {
         MouseController {
             mouse: Point::zero(),
             widget_under_mouse: None,
         }
     }
+
     fn check_widget_under_cursor(&mut self, args: EventArgs) {
         let widget_under_cursor = args.ui.widget_under_cursor(self.mouse);
         if widget_under_cursor != self.widget_under_mouse {
@@ -103,7 +113,7 @@ impl App {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum MouseOverEvent {
     Over,
     Out,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -13,11 +13,15 @@ pub use self::solver::LimnSolver;
 pub use limn_layout::*;
 
 impl WidgetBuilder {
+
+    /// Creates a linear layout with Widgets positioned relatively to each other
     pub fn linear_layout(&mut self, settings: LinearLayoutSettings) -> &mut Self {
         let container = LinearLayout::new(self.layout().deref_mut(), settings);
         self.layout().set_container(container);
         self
     }
+
+    /// Creates a grid-based layout with a certain number of columns
     pub fn grid(&mut self, num_columns: usize) -> &mut Self {
         let container = GridLayout::new(self.layout().deref_mut(), num_columns);
         self.layout().set_container(container);
@@ -27,8 +31,10 @@ impl WidgetBuilder {
 
 #[derive(Clone)]
 pub struct UpdateLayout(pub WidgetRef);
+#[derive(Debug, Copy, Clone)]
 pub struct ResizeWindow;
 pub struct LayoutChanged(pub Vec<(usize, VarType, f64)>);
+#[derive(Debug, Copy, Clone)]
 pub struct LayoutUpdated;
 
 impl App {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,44 +2,60 @@
 
 #![cfg_attr(feature="nightly", feature(core_intrinsics))]
 
-extern crate text_layout;
 #[macro_use]
 extern crate limn_layout;
-extern crate cassowary;
-extern crate rusttype;
-extern crate glutin;
 #[macro_use]
 extern crate lazy_static;
-extern crate linked_hash_map;
-extern crate stable_bst;
 #[macro_use]
 extern crate maplit;
 #[macro_use]
 extern crate downcast_rs;
-extern crate euclid;
 #[macro_use]
 extern crate log;
+
+extern crate text_layout;
+extern crate cassowary;
+extern crate rusttype;
+extern crate glutin;
+extern crate linked_hash_map;
+extern crate stable_bst;
+extern crate euclid;
 extern crate webrender;
 extern crate gleam;
 extern crate app_units;
 extern crate image;
 
+/// Mouse & keyboard handling / delegating functions
 #[macro_use]
 pub mod event;
-pub mod app;
+/// Module for `WidgetBuilder` and callback handlers
 #[macro_use]
 pub mod widget;
+/// Module for layout / resizing handlers and layout solving
 #[macro_use]
 pub mod layout;
+
+/// Module for registering global handlers / window handling
+pub mod app;
+/// Module for various common widgets (button, text, canvas, etc.)
 pub mod widgets;
+/// Drawing functions for images, rectangles, text and ellipses
 pub mod draw;
+/// UI state handling, such as adding / removing widgets,
 pub mod ui;
+/// Points, rects and sizes definitions
 pub mod geometry;
+/// Font, image and texture resources
 pub mod resources;
+/// Color constants. TODO: use CSS instead
 pub mod color;
+/// Keyboard and mouse handling (from `winit`)
 pub mod input;
+/// Re-exports of common crate-internal functions / structs
 pub mod prelude;
+/// Debugging rendering functions
 pub mod render;
+/// Wrapper around `glutin::Window`
 pub mod window;
 
 #[cfg(not(feature="nightly"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,41 @@
 //! Limn is a cross platform, event driven, component based GUI library.
 
+// ---- START CLIPPY CONFIG
+
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
+// Enable clippy if our Cargo.toml file asked us to do so.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+#![warn(missing_copy_implementations,
+        trivial_numeric_casts,
+        trivial_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications)]
+#![cfg_attr(feature="clippy", warn(cast_possible_truncation))]
+#![cfg_attr(feature="clippy", warn(cast_possible_wrap))]
+#![cfg_attr(feature="clippy", warn(cast_precision_loss))]
+#![cfg_attr(feature="clippy", warn(cast_sign_loss))]
+#![cfg_attr(feature="clippy", warn(missing_docs_in_private_items))]
+#![cfg_attr(feature="clippy", warn(mut_mut))]
+
+// Disallow `println!`. Use `debug!` for debug output
+// (which is provided by the `log` crate).
+#![cfg_attr(feature="clippy", warn(print_stdout))]
+
+// This allows us to use `unwrap` on `Option` values (because doing makes
+// working with Regex matches much nicer) and when compiling in test mode
+// (because using it in tests is idiomatic).
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
+// ---- END CLIPPY CONFIG
+
 #![cfg_attr(feature="nightly", feature(core_intrinsics))]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub mod ui;
 pub mod geometry;
 /// Font, image and texture resources
 pub mod resources;
-/// Color constants. TODO: use CSS instead
+/// Color constants
 pub mod color;
 /// Keyboard and mouse handling (from `winit`)
 pub mod input;

--- a/src/render.rs
+++ b/src/render.rs
@@ -51,7 +51,7 @@ impl WebRenderContext {
         let document_id = api.add_document(window.size_u32());
 
         let frame_ready = Arc::new(AtomicBool::new(false));
-        let notifier = Box::new(Notifier::new(events_loop.create_proxy(), frame_ready.clone()));
+        let notifier = Box::new(Notifier::new(events_loop.create_proxy(), Arc::clone(&frame_ready)));
         renderer.set_render_notifier(notifier);
 
         renderer.set_external_image_handler(Box::new(LimnExternalImageHandler));

--- a/src/resources/id.rs
+++ b/src/resources/id.rs
@@ -27,7 +27,7 @@ pub struct IdGen<I> {
     phantom: PhantomData<I>,
 }
 
-impl<I: Id> IdGen<I> {
+impl<I: Id> Default for IdGen<I> {
     fn default() -> Self {
         IdGen {
             id: 0,

--- a/src/resources/id.rs
+++ b/src/resources/id.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::hash::Hash;
-use std::default::Default;
 
 pub trait Id: Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord {
     fn new(index: usize) -> Self;

--- a/src/resources/id.rs
+++ b/src/resources/id.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::hash::Hash;
+use std::default::Default;
 
 pub trait Id: Copy + Clone + Debug + Hash + PartialEq + Eq + PartialOrd + Ord {
     fn new(index: usize) -> Self;
@@ -26,14 +27,25 @@ pub struct IdGen<I> {
     id: usize,
     phantom: PhantomData<I>,
 }
+
 impl<I: Id> IdGen<I> {
-    pub fn new() -> Self {
+    fn default() -> Self {
         IdGen {
             id: 0,
             phantom: PhantomData,
         }
     }
-    pub fn next(&mut self) -> I {
+}
+
+impl<I: Id> IdGen<I> {
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Not to be confused with `std::iterator::Iterator::next()`!
+    /// This function simply increases the Id by 1 while keeping the type
+    pub fn next_id(&mut self) -> I {
         let id = self.id;
         self.id = id.wrapping_add(1);
         Id::new(id)

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -197,8 +197,7 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
             }
             is_opaque
         }
-        ImageFormat::RGB8 => true,
-        ImageFormat::RG8 => true,
+        ImageFormat::RGB8 | ImageFormat::RG8 => true,
         ImageFormat::A8 => false,
         ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
     }
@@ -208,10 +207,10 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
 // These are slow. Gecko's gfx/2d/Swizzle.cpp has better versions
 pub fn premultiply(data: &mut [u8]) {
     for pixel in data.chunks_mut(4) {
-        let a = pixel[3] as u32;
-        let r = pixel[2] as u32;
-        let g = pixel[1] as u32;
-        let b = pixel[0] as u32;
+        let a = u32::from(pixel[3]);
+        let r = u32::from(pixel[2]);
+        let g = u32::from(pixel[1]);
+        let b = u32::from(pixel[0]);
 
         pixel[3] = a as u8;
         pixel[2] = ((r * a + 128) / 255) as u8;

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -3,6 +3,7 @@ pub mod id;
 
 use std::sync::{Mutex, MutexGuard};
 use std::collections::HashMap;
+use std::default::Default;
 
 use webrender::api::*;
 use image;
@@ -59,7 +60,7 @@ impl<I: Id, T> Map<I, T> {
     }
     /// Adds the given resource to the `Map` and returns a unique `Id` for it.
     pub fn insert(&mut self, resource: T) -> I {
-        let id = self.id_gen.next();
+        let id = self.id_gen.next_id();
         self.map.insert(id, resource);
         id
     }
@@ -73,8 +74,9 @@ pub struct Resources {
     pub texture_descriptors: HashMap<u64, ImageDescriptor>,
     pub widget_id: IdGen<WidgetId>,
 }
-impl Resources {
-    pub fn new() -> Self {
+
+impl Default for Resources {
+    fn default() -> Self {
         Resources {
             render: None,
             fonts: HashMap::new(),
@@ -84,8 +86,16 @@ impl Resources {
             widget_id: IdGen::new(),
         }
     }
+}
+
+impl Resources {
+    /// Creates a new `Resources` struct, same as calling `default()`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn widget_id(&mut self) -> WidgetId {
-        self.widget_id.next()
+        self.widget_id.next_id()
     }
 
     pub fn get_image(&mut self, name: &str) -> &ImageInfo {

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -151,6 +151,7 @@ impl Resources {
         &self.fonts[name]
     }
 
+    #[cfg_attr(feature = "cargo-clippy", allow(map_entry))]
     pub fn get_font_instance(&mut self, name: &str, font_size: f32) -> &FontInstanceKey {
         let font_key = self.get_font(name).key;
         let size = app_units::Au::from_f32_px(text_layout::px_to_pt(font_size));

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -30,12 +30,13 @@ pub fn resources() -> MutexGuard<'static, Resources> {
 
 named_id!(WidgetId);
 
+#[derive(Clone)]
 pub struct FontInfo {
     pub key: FontKey,
     pub info: Font,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct ImageInfo {
     pub key: ImageKey,
     pub info: ImageDescriptor,
@@ -47,13 +48,21 @@ pub struct Map<I, T> {
     map: HashMap<I, T>,
 }
 
-impl<I: Id, T> Map<I, T> {
-    pub fn new() -> Self {
+impl<I: Id, T> Default for Map<I, T> {
+    #[inline]
+    fn default() -> Self {
         Map {
             id_gen: IdGen::new(),
             map: HashMap::new(),
         }
     }
+}
+impl<I: Id, T> Map<I, T> {
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Borrow the resource associated with the given `Id`.
     pub fn get(&self, id: I) -> Option<&T> {
         self.map.get(&id)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -242,8 +242,12 @@ impl App {
         });
     }
 }
+
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetAttachedEvent;
+#[derive(Debug, Copy, Clone)]
 pub struct WidgetDetachedEvent;
+#[derive(Debug, Copy, Clone)]
 pub struct ChildAttachedEvent(pub WidgetId, pub LayoutVars);
 
 pub enum ChildrenUpdatedEvent {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -56,7 +56,7 @@ impl WidgetRef {
         LayoutGuard { guard: self.0.borrow() }
     }
     pub fn layout_vars(&self) -> LayoutVars {
-        self.0.borrow().layout.vars.clone()
+        self.0.borrow().layout.vars
     }
     pub fn props(&self) -> PropsGuard {
         PropsGuard { guard: self.0.borrow() }
@@ -143,7 +143,7 @@ impl WidgetRef {
             });
         });
         self.event(::ui::WidgetAttachedEvent);
-        self.event(::ui::ChildAttachedEvent(self.id(), child.layout().vars.clone()));
+        self.event(::ui::ChildAttachedEvent(self.id(), child.layout().vars));
         self.event(::ui::ChildrenUpdatedEvent::Added(child));
         self
     }
@@ -193,7 +193,7 @@ impl WidgetRef {
             let mut handlers: Vec<Rc<RefCell<EventHandlerWrapper>>> = Vec::new();
             if let Some(event_handlers) = widget.handlers.get_mut(&type_id) {
                 for handler in event_handlers {
-                    handlers.push(handler.clone());
+                    handlers.push(Rc::clone(&handler));
                 }
             }
             handlers

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -193,7 +193,7 @@ impl WidgetRef {
             let mut handlers: Vec<Rc<RefCell<EventHandlerWrapper>>> = Vec::new();
             if let Some(event_handlers) = widget.handlers.get_mut(&type_id) {
                 for handler in event_handlers {
-                    handlers.push(Rc::clone(&handler));
+                    handlers.push(Rc::clone(handler));
                 }
             }
             handlers

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -402,6 +402,7 @@ impl Widget {
 }
 
 /// Used to initialize and modify a Widget before it's been added to a parent Widget
+#[derive(Debug, Clone)]
 pub struct WidgetBuilder {
     pub widget: WidgetRef,
 }

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -140,4 +140,5 @@ macro_rules! style {
     };
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct StyleUpdated;

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -143,8 +143,9 @@ pub struct PushButtonBuilder {
 
 widget_wrapper!(PushButtonBuilder);
 
-impl PushButtonBuilder {
-    pub fn new() -> Self {
+impl Default for PushButtonBuilder {
+    #[inline]
+    fn default() -> Self {
         let mut widget = WidgetBuilder::new("push_button");
         widget
             .set_draw_state_with_style(RectState::new(), STYLE_BUTTON.clone())
@@ -157,6 +158,14 @@ impl PushButtonBuilder {
 
         PushButtonBuilder { widget: widget }
     }
+}
+impl PushButtonBuilder {
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the text of the button
     pub fn set_text(&mut self, text: &'static str) -> &mut Self {
 
         let style = style!(parent: STYLE_BUTTON_TEXT,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -46,7 +46,7 @@ lazy_static! {
     };
 }
 
-// show whether button is held down or not
+/// Show whether button is held down or not
 fn button_handle_mouse_down(event: &WidgetMouseButton, mut args: EventArgs) {
     if !args.widget.props().contains(&Property::Inactive) {
         let &WidgetMouseButton(state, _) = event;
@@ -57,11 +57,13 @@ fn button_handle_mouse_down(event: &WidgetMouseButton, mut args: EventArgs) {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum ToggleEvent {
     On,
     Off,
 }
-// show whether toggle button is activated
+
+/// Show whether toggle button is activated
 fn toggle_button_handle_mouse(event: &WidgetMouseButton, mut args: EventArgs) {
     if let WidgetMouseButton(glutin::ElementState::Released, _) = *event {
         let activated = args.widget.props().contains(&Property::Activated);
@@ -78,10 +80,11 @@ fn toggle_button_handle_mouse(event: &WidgetMouseButton, mut args: EventArgs) {
 pub struct ToggleButtonBuilder {
     pub widget: WidgetBuilder,
 }
+
 widget_wrapper!(ToggleButtonBuilder);
 
-impl ToggleButtonBuilder {
-    pub fn new() -> Self {
+impl Default for ToggleButtonBuilder {
+    fn default() -> Self {
         let mut widget = WidgetBuilder::new("toggle_button");
         widget
             .set_draw_state_with_style(RectState::new(), STYLE_BUTTON.clone())
@@ -95,6 +98,16 @@ impl ToggleButtonBuilder {
 
         ToggleButtonBuilder { widget: widget }
     }
+}
+
+impl ToggleButtonBuilder {
+
+    /// Creates a new, default ToggleButtonBuilder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the text of the button (register on / off events)
     pub fn set_text(&mut self, on_text: &'static str, off_text: &'static str) -> &mut Self {
 
         let style = style!(parent: STYLE_BUTTON_TEXT,
@@ -114,6 +127,8 @@ impl ToggleButtonBuilder {
         self.widget.add_child(button_text_widget);
         self
     }
+
+    /// Callback function to be called when the button is toggled
     pub fn on_toggle<F>(&mut self, callback: F) -> &mut Self
         where F: Fn(&ToggleEvent, EventArgs) + 'static
     {
@@ -125,6 +140,7 @@ impl ToggleButtonBuilder {
 pub struct PushButtonBuilder {
     pub widget: WidgetBuilder,
 }
+
 widget_wrapper!(PushButtonBuilder);
 
 impl PushButtonBuilder {

--- a/src/widgets/drag.rs
+++ b/src/widgets/drag.rs
@@ -6,7 +6,7 @@ use input::mouse::{MouseMoved, MouseButton, WidgetMouseButton};
 use geometry::{Point, Vector};
 use app::App;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct DragEvent {
     pub state: DragState,
     /// mouse position
@@ -24,6 +24,7 @@ pub enum DragState {
     End,
 }
 
+#[derive(Debug, Clone)]
 struct DragInputHandler {
     widget: Option<WidgetRef>,
     position: Point,
@@ -74,6 +75,7 @@ impl EventHandler<DragInputEvent> for DragInputHandler {
     }
 }
 
+#[derive(Debug, Clone)]
 enum DragInputEvent {
     WidgetPressed(WidgetRef),
     MouseMoved(Point),

--- a/src/widgets/drag.rs
+++ b/src/widgets/drag.rs
@@ -17,7 +17,7 @@ pub struct DragEvent {
     pub change: Vector,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DragState {
     Start,
     Moved,

--- a/src/widgets/edit_text.rs
+++ b/src/widgets/edit_text.rs
@@ -51,8 +51,8 @@ pub struct EditTextBuilder {
     pub text_widget: WidgetBuilder,
 }
 
-impl EditTextBuilder {
-    pub fn new() -> Self {
+impl Default for EditTextBuilder {
+    fn default() -> Self {
         let default_border = Some((1.0, GRAY_70));
         let focused_border = Some((1.0, BLUE));
         let rect_style = style!(
@@ -87,7 +87,14 @@ impl EditTextBuilder {
             text_widget: text_widget,
         }
     }
+}
+impl EditTextBuilder {
+    /// Creates a new `EditTextBuilder`
+    pub fn new() -> Self {
+        Self::default()
+    }
 
+    /// Sets the callback which is used on changing the edited text
     pub fn on_text_changed<F>(&mut self, callback: F) -> &mut Self
         where F: Fn(&TextUpdated, EventArgs) + 'static
     {
@@ -97,6 +104,7 @@ impl EditTextBuilder {
 }
 
 widget_builder!(EditTextBuilder);
+
 impl Into<WidgetBuilder> for EditTextBuilder {
     fn into(mut self) -> WidgetBuilder {
         self.widget.add_child(self.text_widget);
@@ -108,6 +116,7 @@ impl Into<WidgetBuilder> for EditTextBuilder {
 struct TextUpdatedHandler {
     size_constraints: Vec<Constraint>,
 }
+
 impl EventHandler<StyleUpdated> for TextUpdatedHandler {
     fn handle(&mut self, _: &StyleUpdated, mut args: EventArgs) {
         args.widget.update_layout(|layout| {

--- a/src/widgets/glcanvas.rs
+++ b/src/widgets/glcanvas.rs
@@ -1,6 +1,7 @@
 use widget::WidgetBuilder;
 pub use draw::glcanvas::GLCanvasState;
 
+#[derive(Debug, Copy, Clone)]
 pub struct GLCanvasBuilder;
 
 impl GLCanvasBuilder {

--- a/src/widgets/glcanvas.rs
+++ b/src/widgets/glcanvas.rs
@@ -5,6 +5,7 @@ pub use draw::glcanvas::GLCanvasState;
 pub struct GLCanvasBuilder;
 
 impl GLCanvasBuilder {
+    /// Creates a new `GLCanvasBuilder`, returns it in form of a `WidgetBuilder`
     pub fn new(name: &str, texture_id: u64) -> WidgetBuilder {
         let image_draw_state = GLCanvasState::new(name, texture_id);
         let mut widget = WidgetBuilder::new("glcanvas");

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -2,6 +2,7 @@ use widget::WidgetBuilder;
 use draw::image::ImageState;
 use layout::constraint::*;
 
+#[derive(Debug, Copy, Clone)]
 pub struct ImageBuilder;
 
 impl ImageBuilder {

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -6,6 +6,7 @@ use layout::constraint::*;
 pub struct ImageBuilder;
 
 impl ImageBuilder {
+    #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
     pub fn new(file: &str) -> WidgetBuilder {
         let image_draw_state = ImageState::new(file);
         let image_size = image_draw_state.measure();

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -55,6 +55,7 @@ impl EventHandler<ListItemSelected> for ListHandler {
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn list_handle_deselect(_: &ClickEvent, args: EventArgs) {
     args.widget.event(ListItemSelected { widget: None });
 }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -84,13 +84,11 @@ pub struct ListBuilder {
     pub widget: WidgetBuilder,
 }
 
-
 widget_wrapper!(ListBuilder);
 
-impl ListBuilder {
-
-    /// Creates a new `ListBuilder`
-    pub fn new() -> Self {
+impl Default for ListBuilder {
+    #[inline]
+    fn default() -> Self {
         let layout_settings = LinearLayoutSettings::new(Orientation::Vertical);
 
         let mut widget = WidgetBuilder::new("list");
@@ -102,6 +100,13 @@ impl ListBuilder {
         ListBuilder {
             widget: widget,
         }
+    }
+}
+impl ListBuilder {
+
+    /// Creates a new `ListBuilder`
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Sets the closure to run when a list item is selected

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -55,7 +55,7 @@ impl EventHandler<ListItemSelected> for ListHandler {
     }
 }
 
-fn list_handle_deselect(_: &ClickEvent, args: &EventArgs) {
+fn list_handle_deselect(_: &ClickEvent, args: EventArgs) {
     args.widget.event(ListItemSelected { widget: None });
 }
 

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -18,8 +18,9 @@ pub struct ScrollBuilder {
     content: Option<WidgetBuilder>,
     scrollbars: Option<(WidgetBuilder, SliderBuilder, SliderBuilder)>,
 }
-impl ScrollBuilder {
-    pub fn new() -> Self {
+
+impl Default for ScrollBuilder {
+    fn default() -> Self {
         let widget = WidgetBuilder::new("scroll");
 
         let mut content_holder = WidgetBuilder::new("content_holder");
@@ -32,10 +33,23 @@ impl ScrollBuilder {
             scrollbars: None,
         }
     }
+}
+
+impl ScrollBuilder {
+
+    /// Creates a new ScrollBuilder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the content on which the scroll function should be implemented
     pub fn add_content<C: Into<WidgetBuilder>>(&mut self, widget: C) -> &mut Self {
         self.content = Some(widget.into());
         self
     }
+
+    /// Add a scrollbar. Scrolling can be done independently,
+    /// even if no scroll bar is shown.
     pub fn add_scrollbar(&mut self) -> &mut Self {
         let mut scrollbar_h = SliderBuilder::new();
         scrollbar_h.set_name("scrollbar_h");
@@ -315,9 +329,7 @@ impl EventHandler<ScrollParentEvent> for ScrollParent {
 }
 fn get_scroll(event: glutin::MouseScrollDelta) -> Vector {
     let vec = match event {
-        glutin::MouseScrollDelta::LineDelta(x, y) => {
-            Vector::new(-x, y)
-        }
+        glutin::MouseScrollDelta::LineDelta(x, y) |
         glutin::MouseScrollDelta::PixelDelta(x, y) => {
             Vector::new(-x, y)
         }

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -73,6 +73,7 @@ impl Default for SliderBuilder {
         }
     }
 }
+
 impl SliderBuilder {
     pub fn new() -> Self {
         Self::default()
@@ -84,7 +85,7 @@ impl SliderBuilder {
         self
     }
 
-    /// Sets the scrollbar style. TODO: Replace with CSS
+    /// Sets the scrollbar style
     pub fn scrollbar_style(&mut self) -> &mut Self {
         self.variable_handle_size = true;
         self.handle_style = HandleStyle::Square;

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -15,22 +15,25 @@ use draw::ellipse::{EllipseState, EllipseStyle};
 use geometry::{RectExt, Point};
 use color::*;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Orientation {
     Horizontal,
     Vertical,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum HandleStyle {
     Round,
     Square
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum BarStyle {
     NarrowRound,
     Wide,
 }
 
+#[derive(Debug)]
 pub struct SliderBuilder {
     pub widget: WidgetBuilder,
     pub slider_handle: WidgetBuilder,
@@ -47,8 +50,9 @@ pub struct SliderBuilder {
     pub width: f32,
 }
 
-impl SliderBuilder {
-    pub fn new() -> Self {
+impl Default for SliderBuilder {
+    #[inline]
+    fn default() -> Self {
         let widget = WidgetBuilder::new("slider");
 
         let slider_handle = WidgetBuilder::new("slider_handle");
@@ -68,10 +72,19 @@ impl SliderBuilder {
             width: 30.0,
         }
     }
+}
+impl SliderBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the orientation of the slider to vertical
     pub fn make_vertical(&mut self) -> &mut Self {
         self.orientation = Orientation::Vertical;
         self
     }
+
+    /// Sets the scrollbar style. TODO: Replace with CSS
     pub fn scrollbar_style(&mut self) -> &mut Self {
         self.variable_handle_size = true;
         self.handle_style = HandleStyle::Square;
@@ -83,6 +96,7 @@ impl SliderBuilder {
         self.width = 15.0;
         self
     }
+
     pub fn set_width(&mut self, width: f32) -> &mut Self {
         self.width = width;
         self
@@ -232,16 +246,17 @@ impl Into<WidgetBuilder> for SliderBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SliderEvent {
     pub value: f32,
     pub offset: f32,
     pub dragging: bool,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct SetSliderValue(pub f32);
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 enum SliderInputEvent {
     Drag(DragEvent),
     Click(Point),
@@ -249,6 +264,7 @@ enum SliderInputEvent {
     LayoutUpdated,
 }
 
+#[derive(Debug, Clone)]
 struct SliderHandler {
     orientation: Orientation,
     range: Range<f32>,
@@ -258,6 +274,7 @@ struct SliderHandler {
     drag_start_val: f32,
     last_val: f32,
 }
+
 impl SliderHandler {
     fn new(orientation: Orientation, range: Range<f32>, slider_ref: WidgetRef, handle_ref: WidgetRef, init_value: Option<f32>) -> Self {
         let value = init_value.unwrap_or(range.start);

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -218,7 +218,7 @@ impl Into<WidgetBuilder> for SliderBuilder {
         let widget_ref = widget.widget_ref();
         slider_handle
             .add_handler_fn(move |event: &DragEvent, _| {
-                widget_ref.event(SliderInputEvent::Drag(event.clone()));
+                widget_ref.event(SliderInputEvent::Drag(*event));
             })
             .make_draggable();
 

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -10,6 +10,8 @@ use layout::constraint::*;
 pub struct TextBuilder;
 
 impl TextBuilder {
+    /// Returns a default TextBuilder (in form of a WidgetBuilder)
+    #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
     pub fn new(text: &str) -> WidgetBuilder {
         let text_draw_state = TextState::new(text);
         let mut widget = WidgetBuilder::new(text);

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -6,6 +6,7 @@ use draw::text::{TextState, TextStyle};
 use event::{EventHandler, EventArgs};
 use layout::constraint::*;
 
+#[derive(Debug, Copy, Clone)]
 pub struct TextBuilder;
 
 impl TextBuilder {

--- a/text_layout/src/cursor.rs
+++ b/text_layout/src/cursor.rs
@@ -296,7 +296,7 @@ pub fn xys_per_line_from_text<'a>(text: &'a str,
     let lines = line_infos.clone();
     let lines_with_rects = lines.zip(line_rects.clone());
     XysPerLineFromText {
-        xys_per_line: super::cursor::xys_per_line(lines_with_rects, font, text, font_size),
+        xys_per_line: xys_per_line(lines_with_rects, font, text, font_size),
     }
 }
 
@@ -445,7 +445,7 @@ impl<'a, 'b> Iterator for Xs<'a, 'b> {
                 .map(|g| {
                     g.pixel_bounding_box()
                         .map(|r| r.max.x as f32)
-                        .unwrap_or_else(|| x + g.unpositioned().h_metrics().advance_width as f32)
+                        .unwrap_or_else(|| x + g.unpositioned().h_metrics().advance_width)
                 });
             x
         })

--- a/text_layout/src/glyph.rs
+++ b/text_layout/src/glyph.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> Iterator for GlyphRects<'a, 'b> {
             let left = *next_left;
             let right = g.pixel_bounding_box()
                 .map(|bb| bb.max.x as f32)
-                .unwrap_or_else(|| left + g.unpositioned().h_metrics().advance_width as f32);
+                .unwrap_or_else(|| left + g.unpositioned().h_metrics().advance_width);
             *next_left = right;
             let x = Range::new(left, right);
             Rect::from_ranges(x, y)

--- a/text_layout/src/lib.rs
+++ b/text_layout/src/lib.rs
@@ -1,5 +1,41 @@
 //! Text layout logic.
 
+// ---- START CLIPPY CONFIG
+
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
+// Enable clippy if our Cargo.toml file asked us to do so.
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
+#![warn(missing_copy_implementations,
+        trivial_numeric_casts,
+        trivial_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications)]
+#![cfg_attr(feature="clippy", warn(cast_possible_truncation))]
+#![cfg_attr(feature="clippy", warn(cast_possible_wrap))]
+#![cfg_attr(feature="clippy", warn(cast_precision_loss))]
+#![cfg_attr(feature="clippy", warn(cast_sign_loss))]
+#![cfg_attr(feature="clippy", warn(missing_docs_in_private_items))]
+#![cfg_attr(feature="clippy", warn(mut_mut))]
+
+// Disallow `println!`. Use `debug!` for debug output
+// (which is provided by the `log` crate).
+#![cfg_attr(feature="clippy", warn(print_stdout))]
+
+// This allows us to use `unwrap` on `Option` values (because doing makes
+// working with Regex matches much nicer) and when compiling in test mode
+// (because using it in tests is idiomatic).
+#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
+#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
+#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+
+// ---- START CLIPPY CONFIG
+
 extern crate rusttype;
 extern crate euclid;
 

--- a/text_layout/src/lib.rs
+++ b/text_layout/src/lib.rs
@@ -180,11 +180,11 @@ impl<'a, I> Iterator for Lines<'a, I>
 /// Converts the given font size in "points" to its font size in pixels.
 /// assumes 96 dpi display. 1 pt = 1/72"
 pub fn pt_to_px(font_size_in_points: f32) -> f32 {
-    (font_size_in_points * 4.0) as f32 / 3.0
+    (font_size_in_points * 4.0) / 3.0
 }
 
 pub fn px_to_pt(font_size_in_px: f32) -> f32 {
-    (font_size_in_px * 3.0) as f32 / 4.0
+    (font_size_in_px * 3.0) / 4.0
 }
 
 /// Converts the given font size in "points" to a uniform `rusttype::Scale`.

--- a/text_layout/src/line.rs
+++ b/text_layout/src/line.rs
@@ -244,7 +244,7 @@ impl<I> LineRects<I>
             let total_text_height = num_lines as f32 * line_height;
             let total_text_y_range = Range::new(0.0, total_text_height);
             let total_text_y = total_text_y_range.align_start_of(bounding_y);
-            let range = Range::new(0.0, font_size as f32);
+            let range = Range::new(0.0, font_size);
             let y = range.align_start_of(total_text_y);
 
             Rect::from_ranges(x, y)
@@ -290,8 +290,9 @@ impl<I> Iterator for LineRects<I>
 ///
 /// Lines that do not contain any selected text will be skipped.
 pub struct SelectedLineRects<'a, I> {
-    selected_glyph_rects_per_line: super::glyph::SelectedGlyphRectsPerLine<'a, I>,
+    selected_glyph_rects_per_line: SelectedGlyphRectsPerLine<'a, I>,
 }
+
 impl<'a, I> SelectedLineRects<'a, I>
     where I: Iterator<Item = (&'a str, Rect)>
 {
@@ -349,7 +350,7 @@ fn advance_width(ch: char, font: &Font, scale: Scale, last_glyph: &mut Option<Gl
         .unwrap_or(0.0);
     let advance_width = g.h_metrics().advance_width;
     *last_glyph = Some(g.id());
-    (kern + advance_width) as f32
+    (kern + advance_width)
 }
 
 fn peek_next_char(char_indices: &mut Peekable<CharIndices>, next_char_expected: char) -> bool {
@@ -498,7 +499,7 @@ fn next_break_by_whitespace(text: &str,
 
 /// Produce the width of the given line of text including spaces (i.e. ' ').
 pub fn width(text: &str, font: &Font, font_size: f32) -> f32 {
-    let scale = Scale::uniform(font_size as f32);
+    let scale = Scale::uniform(font_size);
     let point = rusttype::Point { x: 0.0, y: 0.0 };
 
     let mut total_w = 0.0;
@@ -508,5 +509,6 @@ pub fn width(text: &str, font: &Font, font_size: f32) -> f32 {
             None => total_w += g.unpositioned().h_metrics().advance_width,
         }
     }
-    total_w as f32
+
+    total_w
 }


### PR DESCRIPTION
This branch adds missing information, as well as clippy lints. This fixes roughly 200 clippy lints and prevents lots of bugs, ranging from floating-point errors to performance issues (lots of types could implement `Copy` and `Default`, but didn't).

So that's for the clippy lints. But please, DOCUMENT stuff. I can't guess what functions are supposed to do in a bigger picture, which is horrible for maintenance. One comment per function at least, please.

Notable changes:

- `Event` is now `Copy`. Meaning, you don't have to call `.clone()` on it anymore.
- `IdRef.next()` has been renamed to `IdRef.next_id()` because it could be confused with `std::iterator::Iterator::next()`.
- `WidgetBuilder` has a new function: `remove_prop()`, which removes a property
- `WidgetBuilder` can now accept both `String` and `&str` for naming