### PR TITLE
Using font-loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ maplit = "0.1.4"
 downcast-rs = "1.0.0"
 multi_mut = "0.1.3"
 
+font-loader = "0.4.2"
+
 [dev-dependencies]
 find_folder = "0.3.0"
 chrono = "0.4"

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -45,7 +45,7 @@ impl TextState {
     pub fn measure(&self) -> Size {
         let line_height = self.line_height();
         let mut resources = resources();
-        let font = resources.get_font(&self.font);
+        let font = resources.get_font(&self.font).unwrap();
         text_layout::get_text_size(
             &self.text,
             &font.info,
@@ -62,7 +62,7 @@ impl TextState {
     pub fn text_fits(&self, text: &str, bounds: Rect) -> bool {
         let line_height = self.line_height();
         let mut resources = resources();
-        let font = resources.get_font(&self.font);
+        let font = resources.get_font(&self.font).unwrap();
         let height = text_layout::get_text_height(
             text,
             &font.info,
@@ -75,7 +75,7 @@ impl TextState {
     fn get_line_rects(&self, bounds: Rect) -> Vec<Rect> {
         let line_height = self.line_height();
         let mut resources = resources();
-        let font = resources.get_font(&self.font);
+        let font = resources.get_font(&self.font).unwrap();
         text_layout::get_line_rects(
             &self.text,
             bounds,
@@ -89,7 +89,7 @@ impl TextState {
         let line_height = self.line_height();
         let descent = self.v_metrics().descent;
         let mut resources = resources();
-        let font = resources.get_font(&self.font);
+        let font = resources.get_font(&self.font).unwrap();
         text_layout::get_positioned_glyphs(
             &self.text,
             bounds,
@@ -110,7 +110,7 @@ impl TextState {
     }
     fn v_metrics(&self) -> VMetrics {
         let mut resources = resources();
-        let font = resources.get_font(&self.font);
+        let font = resources.get_font(&self.font).unwrap();
         font.info.v_metrics(Scale::uniform(self.font_size))
     }
 }
@@ -122,7 +122,7 @@ impl Draw for TextState {
             let line_rects = self.get_line_rects(bounds);
             let v_metrics = self.v_metrics();
             let mut resources = resources();
-            let font = resources.get_font(&self.font);
+            let font = resources.get_font(&self.font).unwrap();
             for mut rect in line_rects {
                 render::draw_rect_outline(rect, CYAN, renderer);
                 rect.origin.y = rect.bottom() + v_metrics.descent;

--- a/src/draw/text.rs
+++ b/src/draw/text.rs
@@ -26,7 +26,7 @@ impl Default for TextState {
     fn default() -> Self {
         TextState {
             text: "".to_owned(),
-            font: "NotoSans/NotoSans-Regular".to_owned(),
+            font: "Sans".to_owned(),
             font_size: 24.0,
             text_color: BLACK,
             background_color: TRANSPARENT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate webrender;
 extern crate gleam;
 extern crate app_units;
 extern crate image;
+extern crate font_loader;
 
 #[macro_use]
 pub mod event;

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -8,6 +8,7 @@ use webrender::api::*;
 use image;
 use rusttype;
 use app_units;
+use font_loader::system_fonts;
 
 use text_layout;
 
@@ -202,16 +203,16 @@ pub fn premultiply(data: &mut [u8]) {
 }
 
 fn load_font_data(name: &str) -> Result<Vec<u8>, ::std::io::Error> {
-    use std::fs::File;
-    use std::io::Read;
-    let mut file = File::open(format!("assets/fonts/{}.ttf", name)).expect("Font missing");
-    let mut data = Vec::new();
-    try!(file.read_to_end(&mut data));
-    Ok(data)
+    let property = system_fonts::FontPropertyBuilder::new().family(name).build();
+    let font = system_fonts::get(&property)
+        .map(|tuple| tuple.0)
+        .ok_or(::std::io::Error::new(::std::io::ErrorKind::NotFound, "Font not found"));
+    font
 }
 
 pub fn load_font(name: &str) -> Result<Font, ::std::io::Error> {
     let data = try!(load_font_data(name));
     let collection = rusttype::FontCollection::from_bytes(data);
-    Ok(collection.into_font().unwrap())
+    let mut font_iter = collection.into_fonts();
+    font_iter.next().ok_or(::std::io::Error::new(::std::io::ErrorKind::InvalidData, "Bad font format"))
 }

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -134,7 +134,7 @@ impl Resources {
         Ok(&self.fonts[name])
     }
 
-    pub fn add_font(&mut self, name: &str, font_bytes: Vec<u8>) -> Result<&FontInfo, ::std::io::Error> {
+    pub fn put_font(&mut self, name: &str, font_bytes: Vec<u8>) -> Result<&FontInfo, ::std::io::Error> {
         let font = try!(font_from_bytes(font_bytes.clone()));
 
         let key = self.render.as_ref().unwrap().generate_font_key();

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -118,19 +118,34 @@ impl Resources {
         &self.images[name]
     }
 
+    #[deprecated(note = "may panic, instead of this use get_font_or_load_from_system or get_font_if_present")]
     pub fn get_font(&mut self, name: &str) -> &FontInfo {
-        if !self.fonts.contains_key(name) {
-            let data = load_font_data(name).unwrap();
-            let key = self.render.as_ref().unwrap().generate_font_key();
-            let mut resources = ResourceUpdates::new();
-            resources.add_raw_font(key, data, 0);
+        self.get_font_or_load_from_system(name).unwrap()
+    }
 
-            let font = load_font(name).unwrap();
-            self.render.as_ref().unwrap().update_resources(resources);
-            let font_info = FontInfo { key: key, info: font };
-            self.fonts.insert(name.to_owned(), font_info);
+    pub fn get_font_if_present(&mut self, name: &str) -> Option<&FontInfo> {
+        self.fonts.get(name)
+    }
+
+    pub fn get_font_or_load_from_system(&mut self, name: &str) -> Result<&FontInfo, ::std::io::Error> {
+        if !self.fonts.contains_key(name) {
+            return self.add_font(name, try!(load_system_font_by_family_name(name)));
         }
-        &self.fonts[name]
+        Ok(&self.fonts[name])
+    }
+
+    pub fn add_font(&mut self, name: &str, font_bytes: Vec<u8>) -> Result<&FontInfo, ::std::io::Error> {
+        let font = try!(font_from_bytes(font_bytes.clone()));
+
+        let key = self.render.as_ref().unwrap().generate_font_key();
+        let mut resources = ResourceUpdates::new();
+        resources.add_raw_font(key, font_bytes, 0);
+
+        self.render.as_ref().unwrap().update_resources(resources);
+        let font_info = FontInfo { key: key, info: font };
+        self.fonts.insert(name.to_owned(), font_info);
+
+        Ok(&self.fonts[name])
     }
 
     pub fn get_font_instance(&mut self, name: &str, font_size: f32) -> &FontInstanceKey {
@@ -202,7 +217,7 @@ pub fn premultiply(data: &mut [u8]) {
     }
 }
 
-fn load_font_data(name: &str) -> Result<Vec<u8>, ::std::io::Error> {
+fn load_system_font_by_family_name(name: &str) -> Result<Vec<u8>, ::std::io::Error> {
     let property = system_fonts::FontPropertyBuilder::new().family(name).build();
     let font = system_fonts::get(&property)
         .map(|tuple| tuple.0)
@@ -210,9 +225,12 @@ fn load_font_data(name: &str) -> Result<Vec<u8>, ::std::io::Error> {
     font
 }
 
-pub fn load_font(name: &str) -> Result<Font, ::std::io::Error> {
-    let data = try!(load_font_data(name));
-    let collection = rusttype::FontCollection::from_bytes(data);
+fn font_from_bytes(bytes: Vec<u8>) -> Result<Font, ::std::io::Error> {
+    let collection = rusttype::FontCollection::from_bytes(bytes);
     let mut font_iter = collection.into_fonts();
     font_iter.next().ok_or(::std::io::Error::new(::std::io::ErrorKind::InvalidData, "Bad font format"))
+}
+
+pub fn load_font(name: &str) -> Result<Font, ::std::io::Error> {
+    font_from_bytes(try!(load_system_font_by_family_name(name)))
 }


### PR DESCRIPTION
Let's use font-loader to load the font data instead of using hard coded paths, and files.

See #4 