### PR TITLE
Fix flickering when resizing the window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -115,14 +115,10 @@ impl App {
             self.ui.update();
 
             if !self.ui.needs_redraw() && !self.ui.render.frame_ready() {
-                let mut events = Vec::new();
                 events_loop.run_forever(|window_event| {
-                    events.push(window_event);
+                    self.handle_window_event(window_event);
                     glutin::ControlFlow::Break
                 });
-                for event in events {
-                    self.handle_window_event(event);
-                }
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -108,6 +108,7 @@ impl Ui {
             });
         }
         self.needs_redraw = true;
+        self.update();
     }
 
     pub fn check_layout_changes(&mut self) {


### PR DESCRIPTION
The back-buffer must be updated before processing the next window event, or else the window flickers whilst resizing.