### PR TITLE
Update Glutin/Winit, Gleam, Webrender, and Euclid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ homepage = "https://github.com/christolliday/limn"
 limn-core = { path = "core", version = "0.0.1" }
 
 [dev-dependencies]
-euclid = "0.16"
-gleam = "0.4.20"
+euclid = "0.17"
+gleam = "0.5"
 find_folder = "0.3.0"
 chrono = "0.4"
 env_logger = "0.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,16 +9,17 @@ limn-text_layout = { path = "../text_layout", version = "0.0.1" }
 limn-layout = { path = "../layout", version = "0.0.1" }
 cassowary = "0.3.0"
 
-euclid = "0.16"
+euclid = "0.17"
 log = "0.3"
-gleam = "0.4.20"
+gleam = "0.5"
 
-webrender = { git = "https://github.com/servo/webrender", rev = "c383ef73113d0d5f8634385565ce83a4c84ca944" }
+#webrender = { git = "https://github.com/servo/webrender", rev = "c383ef73113d0d5f8634385565ce83a4c84ca944" }
+webrender = { git = "https://github.com/servo/webrender", rev = "34a498f7e46c385a189299e7369e204e1cb2060c" }
 
 stb_truetype = "0.2.1"
 app_units = "0.6"
 rusttype = "0.2.1"
-glutin = "0.13.1"
+glutin = "0.17"
 image = "0.16"
 
 lazy_static = "0.2.2"

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -4,7 +4,7 @@ use std::time::{Instant, Duration};
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use glutin;
+use glutin::{self, dpi::LogicalSize};
 
 use window::Window;
 use ui::Ui;
@@ -68,7 +68,7 @@ impl App {
     fn handle_window_event(&mut self, event: glutin::Event) {
         debug!("handle window event {:?}", event);
         if let glutin::Event::WindowEvent { event, .. } = event {
-            if let glutin::WindowEvent::Resized(width, height) = event {
+            if let glutin::WindowEvent::Resized(LogicalSize {width, height}) = event {
                 // ignore resize events before ui has been measured
                 if self.window_initialized {
                     self.ui.window_resized(Size::new(width as f32, height as f32));

--- a/core/src/geometry.rs
+++ b/core/src/geometry.rs
@@ -14,7 +14,7 @@ use webrender::api::*;
 /// integration, but doesn't imply that the reference frame is a layer. Positions
 /// should generally be relative to the window, where the origin is the top left,
 /// and x and y values increase moving down and to the right.
-pub type DensityIndependentPixel = LayerPixel;
+pub type DensityIndependentPixel = LayoutPixel;
 
 pub type Size = euclid::TypedSize2D<f32, DensityIndependentPixel>;
 pub type Point = euclid::TypedPoint2D<f32, DensityIndependentPixel>;

--- a/core/src/input/mod.rs
+++ b/core/src/input/mod.rs
@@ -23,7 +23,7 @@ impl App {
         self.add_handler(|event: &InputEvent, args: EventArgs| {
             let InputEvent(event) = event.clone();
             match event {
-                glutin::WindowEvent::Closed => {
+                glutin::WindowEvent::CloseRequested => {
                     args.ui.close();
                 }
                 glutin::WindowEvent::MouseWheel { delta, .. } => {
@@ -33,7 +33,7 @@ impl App {
                     args.widget.event(MouseButton(state, button));
                 }
                 glutin::WindowEvent::CursorMoved { position, .. } => {
-                    let point = Point::new(position.0 as f32, position.1 as f32);
+                    let point = Point::new(position.x as f32, position.y as f32);
                     args.widget.event(MouseMoved(point));
                 }
                 glutin::WindowEvent::CursorLeft { .. } => {

--- a/core/src/resources/font.rs
+++ b/core/src/resources/font.rs
@@ -5,7 +5,7 @@ use failure::Error;
 use rusttype;
 use font_loader::system_fonts::{self, FontProperty, FontPropertyBuilder};
 use app_units;
-use webrender::api::{RenderApi, ResourceUpdates, FontKey, FontInstanceKey};
+use webrender::api::{RenderApi, ResourceUpdate, AddFont, AddFontInstance, FontKey, FontInstanceKey};
 
 use text_layout;
 
@@ -102,17 +102,24 @@ impl FontLoader {
 
 fn webrender_load_font(render_api: &RenderApi, data: Vec<u8>) -> Result<FontKey, io::Error> {
     let key = render_api.generate_font_key();
-    let mut resources = ResourceUpdates::new();
-    resources.add_raw_font(key, data, 0);
-    render_api.update_resources(resources);
+    let update = ResourceUpdate::AddFont(AddFont::Raw(key, data, 0));
+    render_api.update_resources(vec![update]);
     Ok(key)
 }
 
 fn webrender_load_font_instance(render_api: &RenderApi, font_key: FontKey, size: app_units::Au) -> FontInstanceKey {
     let instance_key = render_api.generate_font_instance_key();
-    let mut resources = ResourceUpdates::new();
-    resources.add_font_instance(instance_key, font_key, size, None, None, Vec::new());
-    render_api.update_resources(resources);
+    let update = ResourceUpdate::AddFontInstance(
+        AddFontInstance {
+            key: instance_key,
+            font_key: font_key,
+            glyph_size: size,
+            options: None,
+            platform_options: None,
+            variations: vec![]
+        }
+    );
+    render_api.update_resources(vec![update]);
     instance_key
 }
 

--- a/core/src/ui.rs
+++ b/core/src/ui.rs
@@ -85,7 +85,8 @@ impl Ui {
     }
 
     pub(super) fn window_resized(&mut self, window_dims: Size) {
-        let window_size = self.window.borrow_mut().size_px();
+        let window = self.window.borrow_mut();
+        let window_size = window.size_px();
         self.render.window_resized(window_size);
         let mut root = self.get_root();
 

--- a/core/src/widget/filter.rs
+++ b/core/src/widget/filter.rs
@@ -28,12 +28,11 @@ impl Filter for OpacityFilter {
         if self.alpha != 1.0 {
             renderer.builder.push_stacking_context(
                 &PrimitiveInfo::new(Rect::zero()),
-                ScrollPolicy::Fixed,
                 None,
                 TransformStyle::Flat,
-                None,
                 MixBlendMode::Normal,
                 vec![FilterOp::Opacity(PropertyBinding::Value(self.alpha), self.alpha)],
+                GlyphRasterSpace::Screen,
             );
         }
     }

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -1,6 +1,7 @@
 use gleam::gl;
 use glutin;
 use glutin::GlContext;
+use glutin::dpi::LogicalSize;
 use webrender::api::DeviceUintSize;
 use geometry::Size;
 
@@ -35,22 +36,22 @@ impl Window {
         self.window.swap_buffers().ok();
     }
     pub fn hidpi_factor(&self) -> f32 {
-        self.window.hidpi_factor()
+        self.window.get_hidpi_factor() as f32
     }
     pub fn resize(&mut self, width: u32, height: u32) {
-        self.window.set_inner_size(width, height);
+        self.window.set_inner_size(LogicalSize{width: width as f64, height: height as f64});
     }
     /// Get the size of the client area of the window in actual pixels.
     /// This is the size of the framebuffer
     pub fn size_px(&self) -> DeviceUintSize {
-        let (width, height) = self.window.get_inner_size().unwrap();
-        DeviceUintSize::new(width, height)
+        let LogicalSize{width, height} = self.window.get_inner_size().unwrap();
+        let hidpi = self.hidpi_factor();
+        DeviceUintSize::new(width as u32 * hidpi as u32, height as u32 * hidpi as u32)
     }
     /// Get the size of the client area of the window in density independent pixels.
     pub fn size_dp(&self) -> Size {
-        let (width, height) = self.window.get_inner_size().unwrap();
-        let hidpi = self.hidpi_factor();
-        Size::new(width as f32 / hidpi, height as f32 / hidpi)
+        let LogicalSize{width, height} = self.window.get_inner_size().unwrap();
+        Size::new(width as f32, height as f32)
     }
     pub fn show(&self) {
         self.window.show()

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -9,7 +9,7 @@ use limn::prelude::*;
 fn main() {
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Limn button demo")
-        .with_min_dimensions(100, 100);
+        .with_min_dimensions(glutin::dpi::LogicalSize{width: 100.0, height: 100.0});
     let app = util::init(window_builder);
     let mut root = Widget::new("root");
 

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -170,7 +170,7 @@ impl EventHandler<PeopleEvent> for PeopleHandler {
 fn main() {
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Limn CRUD demo")
-        .with_min_dimensions(100, 100);
+        .with_min_dimensions(glutin::dpi::LogicalSize{width: 100.0, height: 100.0});
     let mut app = util::init(window_builder);
     let mut root = Widget::new("root");
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -15,7 +15,7 @@ use limn::widgets::list;
 fn main() {
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Limn list demo")
-        .with_min_dimensions(100, 300);
+        .with_min_dimensions(glutin::dpi::LogicalSize{width: 100.0, height: 300.0});
     let app = util::init(window_builder);
     let mut root = Widget::new("root");
 

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/christolliday/limn"
 
 [dependencies]
 cassowary = "0.3.0"
-euclid = "0.16"
+euclid = "0.17"
 log = "0.3"
 lazy_static = "0.2.2"
 

--- a/src/draw/ellipse.rs
+++ b/src/draw/ellipse.rs
@@ -36,8 +36,7 @@ fn clip_ellipse(rect: Rect) -> LocalClip {
 }
 
 fn push_ellipse(renderer: &mut RenderBuilder, rect: Rect, clip_rect: Rect, color: Color) {
-    let clip = clip_ellipse(clip_rect);
-    let info = PrimitiveInfo::with_clip(rect, clip);
+    let info = PrimitiveInfo::with_clip_rect(rect, clip_rect);
     renderer.builder.push_rect(&info, color.into());
 }
 

--- a/src/draw/glcanvas.rs
+++ b/src/draw/glcanvas.rs
@@ -26,7 +26,7 @@ impl GLCanvasState {
             channel_index: 0,
             image_type: ExternalImageType::TextureHandle(TextureTarget::Default),
         };
-        let descriptor = ImageDescriptor::new(0, 0, ImageFormat::BGRA8, true);
+        let descriptor = ImageDescriptor::new(0, 0, ImageFormat::BGRA8, true, false);
         let image_info = resources().image_loader.create_image_resource(ImageData::External(data), descriptor);
         GLCanvasState {
             data: data,
@@ -36,7 +36,7 @@ impl GLCanvasState {
 
     pub fn measure(&self) -> Size {
         let descriptor = self.image_info.descriptor;
-        Size::new(descriptor.width as f32, descriptor.height as f32)
+        Size::new(descriptor.size.width as f32, descriptor.size.height as f32)
     }
 }
 
@@ -44,8 +44,8 @@ impl Draw for GLCanvasState {
     fn draw(&mut self, bounds: Rect, _: Rect, renderer: &mut RenderBuilder) {
         let descriptor = self.image_info.descriptor;
         let (bounds_width, bounds_height) = (bounds.width() as u32, bounds.height() as u32);
-        if bounds_width != descriptor.width || bounds_height != descriptor.height {
-            let descriptor = ImageDescriptor::new(bounds_width, bounds_height, ImageFormat::BGRA8, true);
+        if bounds_width != descriptor.size.width || bounds_height != descriptor.size.height {
+            let descriptor = ImageDescriptor::new(bounds_width, bounds_height, ImageFormat::BGRA8, true, false);
             resources().image_loader.update_texture(self.image_info.key, descriptor, self.data);
             self.image_info.descriptor = descriptor;
         }

--- a/src/draw/image.rs
+++ b/src/draw/image.rs
@@ -28,7 +28,7 @@ impl ImageState {
     }
     pub fn measure(&self) -> Size {
         let descriptor = resources().image_loader.get_image(&self.image).unwrap().descriptor;
-        Size::new(descriptor.width as f32, descriptor.height as f32)
+        Size::new(descriptor.size.width as f32, descriptor.size.height as f32)
     }
     pub fn scale(&mut self, scale: Size) {
         self.scale = scale;

--- a/src/draw/rect.rs
+++ b/src/draw/rect.rs
@@ -33,7 +33,7 @@ fn clip_rounded(rect: Rect, radius: f32) -> LocalClip {
 
 fn push_rect(renderer: &mut RenderBuilder, rect: Rect, color: Color, clip_rect: Rect, radius: Option<f32>) {
     let info = if let Some(radius) = radius {
-        PrimitiveInfo::with_clip(rect, clip_rounded(clip_rect, radius))
+        PrimitiveInfo::with_clip_rect(rect, clip_rect)
     } else {
         PrimitiveInfo::new(rect)
     };

--- a/src/widgets/scroll.rs
+++ b/src/widgets/scroll.rs
@@ -300,9 +300,11 @@ impl ScrollParent {
 
 fn get_scroll(event: glutin::MouseScrollDelta) -> Vector {
     let vec = match event {
-        glutin::MouseScrollDelta::LineDelta(x, y) |
-        glutin::MouseScrollDelta::PixelDelta(x, y) => {
+        glutin::MouseScrollDelta::LineDelta(x, y) => {
             Vector::new(-x, y)
+        },
+        glutin::MouseScrollDelta::PixelDelta(glutin::dpi::LogicalPosition{x, y}) => {
+            Vector::new(-x as f32, y as f32)
         }
     };
     vec * 13.0

--- a/text_layout/Cargo.toml
+++ b/text_layout/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/christolliday/limn"
 
 [dependencies]
 rusttype = "0.2.1"
-euclid = "0.16"
+euclid = "0.17"


### PR DESCRIPTION
Not sure how useful this is, but I wanted to update glutin and webrender to see if it would fix https://github.com/christolliday/limn/issues/3. Unfortunately this didn't fix the issue, but I thought I'd put this up for you in case it saves you work in future.

Known issues:
- Ellipse clipping broken as webrender no longer supports this.
- Only list, crud, and button examples updated to work with new glutin.